### PR TITLE
FEATURE: Article images are now stored in memory

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -5,6 +5,7 @@ export type NewsArticle = {
     url: string;
     description?: string;
     img: string;
+    imgElement?: HTMLImageElement;
     date: string;
     name: string;
 };

--- a/src/components/shared/card/card-component.tsx
+++ b/src/components/shared/card/card-component.tsx
@@ -53,7 +53,7 @@ const Card = ({ endpoint, siteName }: CardProps) => {
                                 <img
                                     alt={`${siteName} Image`}
                                     src={article.url}
-                                    className='rounded-t w-full h-64 shadow object-cover'
+                                    className='animate__animated animate__fadeIn rounded-t w-full h-64 shadow object-cover'
                                 />
                             </a>
                         )}

--- a/src/components/shared/news-reel/news-reel-card.tsx
+++ b/src/components/shared/news-reel/news-reel-card.tsx
@@ -29,8 +29,8 @@ const NewsReelCard = ({
             </span>
             <img
                 alt={`${siteName} Image: ${article.title}`}
-                src={article.img}
-                className='w-full min-w-[50%] xl:w-96 h-60 object-cover shadow rounded-t xl:rounded-tr-none xl:rounded-l'
+                src={article.imgElement?.src}
+                className='animate__animated animate__fadeIn w-full min-w-[50%] xl:w-96 h-60 object-cover shadow rounded-t xl:rounded-tr-none xl:rounded-l'
             />
             <div className='w-full p-4 flex flex-col justify-between text-left h-36 md:h-40 xl:h-60 overflow-hidden'>
                 <div>

--- a/src/components/shared/news-reel/news-reel-component.tsx
+++ b/src/components/shared/news-reel/news-reel-component.tsx
@@ -33,7 +33,9 @@ const NewsCarousel = ({ endpoint, siteName }: CardProps) => {
         data.forEach((article) => {
             const img = new Image();
             img.src = article.img;
-            setLoaded(true);
+            img.onload = () => setLoaded(true);
+
+            article.imgElement = img;
         });
 
     useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -154,3 +154,7 @@ body {
 .left-external-link {
     @apply transition-colors ease-in-out duration-100 hover:bg-zinc-100 dark:hover:bg-zinc-900/40 hover:shadow w-full h-12 flex items-center md:rounded p-3;
 }
+
+img {
+    --animate-duration: 0.2s;
+}


### PR DESCRIPTION
Changes:
- News article carousel items now store and pass the preloaded images.
- Added a light animation to loading images when clicking through carousel.

I'm not entirely sure how this works, but I'm assuming by allocating the preloaded image into the passed object we keep that image alive until the object itself is removed.

This was tested while watching network requests and I'm still not certain I believe it works.